### PR TITLE
Fix tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 /.coverage
 /htmlcov
 /.tox
+/.venv
 /venv
 /.vscode
 /site

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ envlist =
     python{3.8,3.9,3.10,3.11,3.12}
 
 [testenv]
-install_command = pip install -e ".[testing]" -U {opts} {packages}
-commands = pytest {posargs}
-allowlist_externals = pytest
+install_command = python -Im pip install {opts} {packages}
+commands = python -Im pytest {posargs}
+deps =
+    .[testing]
 
 basepython =
     python3.8: python3.8


### PR DESCRIPTION
This PR updates tox configuration to properly install the pytest dependency

The default `install_command` is `python -I -m pip install {opts} {packages}` and there's a bash script that will pass packages defined in `deps`. Without deps it looks like it won't run `install_command`.

Also changed how we invoke pytest (via `python -Im`) so there's no need for `allowlist_externals`