### PR TITLE
Tooling updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: pre-commit/action@v2.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: pre-commit/action@v3.0.0
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - uses: pre-commit/action@v3.0.0
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         additional_dependencies: [black==23.9.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.270
+    rev: v0.0.291
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,20 +20,19 @@ repos:
         args: ['--unsafe']
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3
-        args: ['--target-version', 'py37']
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.16.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black==23.9.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.0.270
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==22.12.0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dynamic = ["version"]
-dependencies = []
+dependencies = [
+    "python>=3.8"
+]
+
 [project.optional-dependencies]
 openai = [
     "openai>=1.0.0b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ anthropic = [
     "anthropic>=0.3.11"
 ]
 testing = [
-    "pre-commit>=2.21.0",
+    "pre-commit>=3.4.0",
     "pytest>=7.2.2",
 ]
 docs = [


### PR DESCRIPTION
This PR

- bumps pre-commit, black/blacken-docs, ruff to their latest versions
- uses `actions/checkout@v4` in GHA
- uses `pre-commit/action@v3.0.0` with Python 3.11
- adds min Python dependency on pyproject.toml, and drops the black target in pre-commit ([ref]( https://github.com/psf/black/blob/main/CHANGES.md#2310))